### PR TITLE
fixed Checkstyle

### DIFF
--- a/src/test/java/org/embulk/filter/unnest/TestUnnestFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/unnest/TestUnnestFilterPlugin.java
@@ -22,9 +22,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.msgpack.value.ValueFactory;
 
+import static org.embulk.spi.type.Types.DOUBLE;
 import static org.embulk.spi.type.Types.JSON;
 import static org.embulk.spi.type.Types.STRING;
-import static org.embulk.spi.type.Types.DOUBLE;
 import static org.junit.Assert.assertEquals;
 
 public class TestUnnestFilterPlugin


### PR DESCRIPTION
- There was a checkstyle error in https://github.com/y-abe/embulk-filter-unnest/pull/11 
- With this fix, the error does not seem to occur.
```shell
 (fixed-checkstyle)$ ./gradlew checkstyle

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.4.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1s
3 actionable tasks: 3 up-to-date
```